### PR TITLE
Add support for SSR between targets

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,32 @@ It adds the required presets to the [`babel-loader`](https://yarnpkg.com/en/pack
 
 Now, when your target gets builded, the plugin will check if the target is using webpack and if the framework is React, then it will make the necessary changes to bundle the `JSX` code.
 
+### Server side rendering
+
+> Server side rendering (SSR) is when you render your application on the server (backend) as a string, serve it on the browser and then you app runs in order to add all the JS magic.
+
+Let's say you have a `backend` target with your Node server code, and a `frontend` target with your React code, and you want to require your `frontend` code on the `backend` in order to use `ReactDOM.renderToString(...)`:
+
+For your `backend` target you'll have to define its `framework` property to `react`, so the plugin can include the JSX loader, and then add an extra option to enable SSR from `backend` to `frontend`:
+
+```js
+module.exports = {
+  targets: {
+    backend: {
+      type: 'node',
+      framework: 'react',
+      frameworkOptions: {
+        ssr: ['frontend'],
+      },
+    },
+  },
+};
+```
+
+This new setting (`frameworkOptions.ssr`) is where you tell the plugin that the targets on that list should also have their JSX parsed for you to use on Node.
+
+Done, now you can `require`/`import` files from your `frontend` target on the `backend` target and everything will work.
+
 ### Hot loader
 
 > If you don't know what hot reload is, you should probably watch [Dan Abramov's talk on Hot Reloading with Time Travel](https://www.youtube.com/watch?v=xsSnOQynTHs).

--- a/tests/plugin.test.js
+++ b/tests/plugin.test.js
@@ -24,7 +24,7 @@ describe('plugin:projextReact/main', () => {
     expect(sut.babelLoaderName).toBe('babel-loader');
   });
 
-  it('should register the listeners for the Webpack plugin', () => {
+  it('should register the listeners for the webpack plugin', () => {
     // Given
     const events = {
       on: jest.fn(),
@@ -124,6 +124,7 @@ describe('plugin:projextReact/main', () => {
       use: [
         'babel-loader',
       ],
+      include: [],
     };
     const currentRules = [currentJSLoader];
     let sut = null;
@@ -131,6 +132,7 @@ describe('plugin:projextReact/main', () => {
     let result = null;
     const expectedLoaders = [Object.assign({}, currentJSLoader, {
       use: currentJSLoader.use,
+      include: [],
     })];
     // When
     sut = new ProjextReactPlugin();
@@ -159,6 +161,7 @@ describe('plugin:projextReact/main', () => {
     const currentJSLoader = {
       test: /\.jsx?$/i,
       use: [currentBabelLoader],
+      include: [],
     };
     const currentRules = [currentJSLoader];
     let sut = null;
@@ -172,6 +175,7 @@ describe('plugin:projextReact/main', () => {
     };
     const expectedLoaders = [Object.assign({}, currentJSLoader, {
       use: [expectedBabelLoader],
+      include: [],
     })];
     // When
     sut = new ProjextReactPlugin();
@@ -201,6 +205,7 @@ describe('plugin:projextReact/main', () => {
     const currentJSLoader = {
       test: /\.jsx?$/i,
       use: [currentBabelLoader],
+      include: [],
     };
     const currentRules = [currentJSLoader];
     let sut = null;
@@ -215,6 +220,7 @@ describe('plugin:projextReact/main', () => {
     };
     const expectedLoaders = [Object.assign({}, currentJSLoader, {
       use: [expectedBabelLoader],
+      include: [],
     })];
     // When
     sut = new ProjextReactPlugin();
@@ -225,7 +231,7 @@ describe('plugin:projextReact/main', () => {
     expect(result).toEqual(expectedLoaders);
   });
 
-  it('should update disable the `modules` setting on the Babel config for HMR', () => {
+  it('should disable the `modules` setting on the Babel config for HMR', () => {
     // Given
     const events = {
       on: jest.fn(),
@@ -247,6 +253,7 @@ describe('plugin:projextReact/main', () => {
     const currentJSLoader = {
       test: /\.jsx?$/i,
       use: [currentBabelLoader],
+      include: [],
     };
     const currentRules = [currentJSLoader];
     let sut = null;
@@ -261,6 +268,68 @@ describe('plugin:projextReact/main', () => {
     };
     const expectedLoaders = [Object.assign({}, currentJSLoader, {
       use: [expectedBabelLoader],
+      include: [],
+    })];
+    // When
+    sut = new ProjextReactPlugin();
+    sut.register(app);
+    [[, reducer]] = events.on.mock.calls;
+    result = reducer(currentRules, { target });
+    // Then
+    expect(result).toEqual(expectedLoaders);
+  });
+
+  it('should include other targets paths if the target uses SSR', () => {
+    // Given
+    const events = {
+      on: jest.fn(),
+    };
+    const otherTarget = {
+      name: 'other-target',
+      folders: {
+        source: 'src/other-target',
+      },
+    };
+    const targets = {
+      getTarget: jest.fn(() => otherTarget),
+    };
+    const appServices = {
+      events,
+      targets,
+    };
+    const app = {
+      get: jest.fn((service) => appServices[service]),
+    };
+    const target = {
+      framework: 'react',
+      frameworkOptions: {
+        ssr: [otherTarget.name],
+      },
+    };
+    const currentBabelLoader = {
+      loader: 'babel-loader',
+      options: {},
+    };
+    const currentJSLoader = {
+      test: /\.jsx?$/i,
+      use: [currentBabelLoader],
+      include: [],
+    };
+    const currentRules = [currentJSLoader];
+    let sut = null;
+    let reducer = null;
+    let result = null;
+    const expectedBabelLoader = {
+      loader: 'babel-loader',
+      options: {
+        presets: [['react']],
+      },
+    };
+    const expectedLoaders = [Object.assign({}, currentJSLoader, {
+      use: [expectedBabelLoader],
+      include: [
+        new RegExp(otherTarget.folders.source),
+      ],
     })];
     // When
     sut = new ProjextReactPlugin();


### PR DESCRIPTION
### What does this PR do?

The full description of this PR is on the changes made to the `README.md`:

> Let's say you have a `backend` target with your Node server code, and a `frontend` target with your React code, and you want to require your `frontend` code on the `backend` in order to use `ReactDOM.renderToString(...)`:
>
> For your `backend` target you'll have to define its `framework` property to `react`, so the plugin can include the JSX loader, and then add an extra option to enable SSR from `backend` to `frontend`:
>
> ```js
> module.exports = {
>   targets: {
>     backend: {
>       type: 'node',
>       framework: 'react',
>       frameworkOptions: {
>         ssr: ['frontend'],
>       },
>     },
>   },
> };
> ```
>
> This new setting (`frameworkOptions.ssr`) is where you tell the plugin that the targets on that list should also have their JSX parsed for you to use on Node.
>
> Done, now you can `require`/`import` files from your `frontend` target on the `backend` target and everything will work.

### How should it be tested manually?

```bash
yarn test
# or
npm test
```
