### PR TITLE
Fix SVG loaders for SSR targets

### DIFF
--- a/src/plugin.js
+++ b/src/plugin.js
@@ -9,14 +9,23 @@ class ProjextReactPlugin {
    */
   constructor() {
     /**
-     * A list of reducer events the service will listen for in order to intercept rules
-     * configurations and update them.
-     * @type {Array}
+     * The name of the reducer event the service will listen in order to intercept the rules for
+     * JS files and update them.
+     * @type {string}
      */
-    this.rulesEventsNames = [
-      'webpack-js-rules-configuration-for-node',
-      'webpack-js-rules-configuration-for-browser',
-    ];
+    this.jsRulesEvent = 'webpack-js-rules-configuration';
+    /**
+     * The name of the reducer event the service will listen in order to intercept the rules for
+     * fonts files, and if the target implements SSR, update them.
+     * @type {string}
+     */
+    this.fontsRulesEvent = 'webpack-fonts-rules-configuration';
+    /**
+     * The name of the reducer event the service will listen in order to intercept the rules for
+     * images files, and if the target implements SSR, update them.
+     * @type {string}
+     */
+    this.imagesRulesEvent = 'webpack-images-rules-configuration';
     /**
      * The name of the reducer event the service will listen for and use to update a target entry
      * settings if the target `hot` property is `true`.
@@ -63,19 +72,25 @@ class ProjextReactPlugin {
   }
   /**
    * This is the method called when the plugin is loaded by projext. It just gets the events service
-   * and registers the listeners for the reducer events that handles JS rules and target
-   * configuration.
+   * and registers the listeners for the reducer events that handle the JS rules, fonts rules,
+   * images rules and target configuration.
    * @param {Projext} app The projext main container.
    */
   register(app) {
     const events = app.get('events');
-    // Add the listeners for the rules.
-    this.rulesEventsNames.forEach((eventName) => {
-      events.on(eventName, (rules, params) => (
-        this.updateRules(rules, params.target, app.get('targets'))
-      ));
-    });
-    // Add the listener for the target.
+    // Add the listener for the JS files rules event.
+    events.on(this.jsRulesEvent, (rules, params) => (
+      this.updateJSRules(rules, params.target, app.get('targets'))
+    ));
+    // Add the listener for the font files rules event.
+    events.on(this.fontsRulesEvent, (rules, params) => (
+      this.updateFontsRules(rules, params.target, app.get('targets'))
+    ));
+    // Add the listener for the font files rules event.
+    events.on(this.imagesRulesEvent, (rules, params) => (
+      this.updateImagesRules(rules, params.target, app.get('targets'))
+    ));
+    // Add the listener for the target configuration event.
     events.on(
       this.targetEventName,
       (config, params) => this.updateTargetConfiguration(config, params.target)
@@ -86,11 +101,11 @@ class ProjextReactPlugin {
    * settings and makes the necessary modifications to the Babel loader configuration.
    * @param {Array}   currentRules The list of JS rules for the webpack configuration.
    * @param {Target}  target       The target information.
-   * @param {Targets} targets      The targets service, to get the information of of targets the
+   * @param {Targets} targets      The targets service, to get the information of targets the
    *                               one being processed may need for SSR.
    * @return {Array} The updated list of rules.
    */
-  updateRules(currentRules, target, targets) {
+  updateJSRules(currentRules, target, targets) {
     let updatedRules;
     // If the target `framework` setting is the right one...
     if (target.framework === this.frameworkProperty) {
@@ -102,12 +117,8 @@ class ProjextReactPlugin {
       const babelLoaderIndex = this._findBabelLoaderIndex(baseJSRule.use);
       // If the Babel loader is preset...
       if (babelLoaderIndex > -1) {
-        // ...merge the default options withy any overwrite the target may have.
-        const options = Object.assign(
-          {},
-          this.frameworkOptions,
-          target.frameworkOptions || {}
-        );
+        // ...get the framework options for the target.
+        const options = this._getTargetOptions(target);
         // Push the paths for SSR targets
         baseJSRule.include.push(...options.ssr.map((name) => {
           const targetInfo = targets.getTarget(name);
@@ -125,7 +136,92 @@ class ProjextReactPlugin {
       updatedRules = currentRules;
     }
 
+    // Return the updated rules
     return currentRules;
+  }
+  /**
+   * This method gets called when projext reduces the fonts files rules of a target. It validates
+   * the target settings, and if the target implements SSR, it adds the `include` setting on
+   * the SVG rule for the SSR targets directories.
+   * @param {Array}   currentRules The list of fonts rules for the webpack configuration.
+   * @param {Target}  target       The target information.
+   * @param {Targets} targets      The targets service, to get the SSR targets information.
+   * @return {Array} The updated list of rules.
+   */
+  updateFontsRules(currentRules, target, targets) {
+    let updatedRules;
+    // If the target `framework` setting is the right one...
+    if (target.framework === this.frameworkProperty) {
+      // ...copy the list of rules.
+      updatedRules = currentRules.slice();
+      // Find the loader used for SVG files.
+      const svgLoader = updatedRules.find((rule) => '.svg'.match(rule.test));
+      // If the loader was found...
+      if (svgLoader) {
+        // ...get the target framework options.
+        const options = this._getTargetOptions(target);
+        // If the `include` option is a list, keep it like that, otherwise, convert it into a list.
+        const include = Array.isArray(svgLoader.include) ?
+          svgLoader.include :
+          [svgLoader.include];
+
+        // Loop all the possible SSR targets and add their _"fonts path"_ to the `include` option.
+        include.push(...options.ssr.map((name) => (
+          this._getTargetFontsRegExp(targets.getTarget(name))
+        )));
+
+        // Overwrite the SVG loder `include` option.
+        svgLoader.include = include;
+      }
+    } else {
+      // ...otherwise, just set to return the received rules.
+      updatedRules = currentRules;
+    }
+
+    // Return the updated rules.
+    return updatedRules;
+  }
+  /**
+   * This method gets called when projext reduces the images files rules of a target. It validates
+   * the target settings, and if the target implements SSR, it adds the `exclude` setting on
+   * the SVG rule for the SSR targets fonts directories.
+   * @param {Array}   currentRules The list of fonts rules for the webpack configuration.
+   * @param {Target}  target       The target information.
+   * @param {Targets} targets      The targets service, to get the SSR targets information.
+   * @return {Array} The updated list of rules.
+   */
+  updateImagesRules(currentRules, target, targets) {
+    let updatedRules;
+    // If the target `framework` setting is the right one...
+    if (target.framework === this.frameworkProperty) {
+      // ...copy the list of rules.
+      updatedRules = currentRules.slice();
+      // Find the loader used for SVG files.
+      const svgLoader = updatedRules.find((rule) => '.svg'.match(rule.test));
+      // If the loader was found...
+      if (svgLoader) {
+        // ...get the target framework options.
+        const options = this._getTargetOptions(target);
+        // If the `exclude` option is a list, keep it like that, otherwise, convert it into a list.
+        const exclude = Array.isArray(svgLoader.exclude) ?
+          svgLoader.exclude :
+          [svgLoader.exclude];
+
+        // Loop all the possible SSR targets and add their _"fonts path"_ to the `exclude` option.
+        exclude.push(...options.ssr.map((name) => (
+          this._getTargetFontsRegExp(targets.getTarget(name))
+        )));
+
+        // Overwrite the SVG loder `exclude` option.
+        svgLoader.exclude = exclude;
+      }
+    } else {
+      // ...otherwise, just set to return the received rules.
+      updatedRules = currentRules;
+    }
+
+    // Return the updated rules.
+    return updatedRules;
   }
   /**
    * This method gets called when projext reduces a target configuration for Wepack. It validates
@@ -163,6 +259,34 @@ class ProjextReactPlugin {
     }
 
     return updatedConfiguration;
+  }
+  /**
+   * Merge the default framework options with the overwrites the target may have, and return the
+   * dictionary with the _"final options"_, ready to use.
+   * @param {Target} target The target information.
+   * @return {Object}
+   * @ignore
+   * @access protected
+   */
+  _getTargetOptions(target) {
+    return Object.assign(
+      {},
+      this.frameworkOptions,
+      target.frameworkOptions || {}
+    );
+  }
+  /**
+   * Gets the RegExp for a fonts folder inside a given target source directory. This is used on
+   * the fonts SVG loader to `include` the files and on the images SVG loader to `exclude` them,
+   * that way SVG files inside a folder that matches the RegExp get handled as fonts and if they
+   * don't match it, they get handled as images.
+   * @param {Target} target The target information.
+   * @return {RegExp}
+   * @ignore
+   * @access protected
+   */
+  _getTargetFontsRegExp(target) {
+    return new RegExp(`${target.paths.source}/(?:.*?/)?fonts/.*?`, 'i');
   }
   /**
    * Finds the index of the Babel loader on a list of loaders.

--- a/tests/plugin.test.js
+++ b/tests/plugin.test.js
@@ -12,10 +12,9 @@ describe('plugin:projextReact/main', () => {
     sut = new ProjextReactPlugin();
     // Then
     expect(sut).toBeInstanceOf(ProjextReactPlugin);
-    expect(sut.rulesEventsNames).toEqual([
-      'webpack-js-rules-configuration-for-node',
-      'webpack-js-rules-configuration-for-browser',
-    ]);
+    expect(sut.jsRulesEvent).toBe('webpack-js-rules-configuration');
+    expect(sut.fontsRulesEvent).toBe('webpack-fonts-rules-configuration');
+    expect(sut.imagesRulesEvent).toBe('webpack-images-rules-configuration');
     expect(sut.targetEventName).toBe('webpack-browser-development-configuration');
     expect(sut.frameworkProperty).toBe('react');
     expect(sut.presetName).toBe('react');
@@ -34,8 +33,9 @@ describe('plugin:projextReact/main', () => {
     };
     let sut = null;
     const expectedEvents = [
-      'webpack-js-rules-configuration-for-node',
-      'webpack-js-rules-configuration-for-browser',
+      'webpack-js-rules-configuration',
+      'webpack-fonts-rules-configuration',
+      'webpack-images-rules-configuration',
       'webpack-browser-development-configuration',
     ];
     // When
@@ -50,7 +50,7 @@ describe('plugin:projextReact/main', () => {
     });
   });
 
-  it('shouldn\'t modify the rules of a target with an unknown framework property', () => {
+  it('shouldn\'t modify the JS rules of a target with an unknown framework property', () => {
     // Given
     const events = {
       on: jest.fn(),
@@ -79,7 +79,7 @@ describe('plugin:projextReact/main', () => {
     expect(result).toEqual(currentRules);
   });
 
-  it('shouldn\'t modify the rules of a target that doesn\'t have a Babel loader', () => {
+  it('shouldn\'t modify the JS rules of a target that doesn\'t have a Babel loader', () => {
     // Given
     const events = {
       on: jest.fn(),
@@ -340,6 +340,450 @@ describe('plugin:projextReact/main', () => {
     expect(result).toEqual(expectedLoaders);
   });
 
+  it('shouldn\'t modify the fonts rules of a target with an unknown framework property', () => {
+    // Given
+    const events = {
+      on: jest.fn(),
+    };
+    const app = {
+      get: jest.fn(() => events),
+    };
+    const target = {
+      framework: 'angularjs',
+    };
+    const currentRules = [{
+      test: /\.svg$/i,
+      use: [
+        'some-random-loader',
+      ],
+    }];
+    let sut = null;
+    let reducer = null;
+    let result = null;
+    // When
+    sut = new ProjextReactPlugin();
+    sut.register(app);
+    [, [, reducer]] = events.on.mock.calls;
+    result = reducer(currentRules, { target });
+    // Then
+    expect(result).toEqual(currentRules);
+  });
+
+  it('shouldn\'t modify the fonts rules of a target that doesn\'t have framework options', () => {
+    // Given
+    const events = {
+      on: jest.fn(),
+    };
+    const app = {
+      get: jest.fn(() => events),
+    };
+    const target = {
+      framework: 'react',
+    };
+    const currentRules = [{
+      test: /\.svg$/i,
+      use: [
+        'some-random-loader',
+      ],
+    }];
+    let sut = null;
+    let reducer = null;
+    let result = null;
+    // When
+    sut = new ProjextReactPlugin();
+    sut.register(app);
+    [, [, reducer]] = events.on.mock.calls;
+    result = reducer(currentRules, { target });
+    // Then
+    expect(result).toEqual(currentRules);
+  });
+
+  it('shouldn\'t modify the fonts rules of a target that doesn\'t implement SSR', () => {
+    // Given
+    const events = {
+      on: jest.fn(),
+    };
+    const app = {
+      get: jest.fn(() => events),
+    };
+    const target = {
+      framework: 'react',
+      frameworkOptions: {
+        ssr: [],
+      },
+    };
+    const currentRules = [{
+      test: /\.svg$/i,
+      use: [
+        'some-random-loader',
+      ],
+    }];
+    let sut = null;
+    let reducer = null;
+    let result = null;
+    // When
+    sut = new ProjextReactPlugin();
+    sut.register(app);
+    [, [, reducer]] = events.on.mock.calls;
+    result = reducer(currentRules, { target });
+    // Then
+    expect(result).toEqual(currentRules);
+  });
+
+  it('shouldn\'t modify the fonts rules if there\'s no SVG loader', () => {
+    // Given
+    const events = {
+      on: jest.fn(),
+    };
+    const app = {
+      get: jest.fn(() => events),
+    };
+    const target = {
+      framework: 'react',
+      frameworkOptions: {
+        ssr: [],
+      },
+    };
+    const currentRules = [{
+      test: /\.not-svg$/i,
+      use: [
+        'some-random-loader',
+      ],
+    }];
+    let sut = null;
+    let reducer = null;
+    let result = null;
+    // When
+    sut = new ProjextReactPlugin();
+    sut.register(app);
+    [, [, reducer]] = events.on.mock.calls;
+    result = reducer(currentRules, { target });
+    // Then
+    expect(result).toEqual(currentRules);
+  });
+
+  it('should update the fonts rules to include SSR targets', () => {
+    // Given
+    const events = {
+      on: jest.fn(),
+    };
+    const otherTarget = {
+      name: 'other-target',
+      paths: {
+        source: 'src/other-target',
+      },
+    };
+    const targets = {
+      getTarget: jest.fn(() => otherTarget),
+    };
+    const appServices = {
+      events,
+      targets,
+    };
+    const app = {
+      get: jest.fn((service) => appServices[service]),
+    };
+    const target = {
+      framework: 'react',
+      frameworkOptions: {
+        ssr: [otherTarget.name],
+      },
+    };
+    const currentLoader = {
+      test: /\.svg$/i,
+      include: /fonts/i,
+    };
+    const currentRules = [currentLoader];
+    let sut = null;
+    let reducer = null;
+    let result = null;
+    const expectedRules = [Object.assign({}, currentLoader, {
+      include: [
+        currentLoader.include,
+        new RegExp(`${otherTarget.paths.source}/(?:.*?/)?fonts/.*?`, 'i'),
+      ],
+    })];
+    // When
+    sut = new ProjextReactPlugin();
+    sut.register(app);
+    [, [, reducer]] = events.on.mock.calls;
+    result = reducer(currentRules, { target });
+    // Then
+    expect(result).toEqual(expectedRules);
+  });
+
+  it('should update the fonts rules even if it already includes an `include` setting', () => {
+    // Given
+    const events = {
+      on: jest.fn(),
+    };
+    const otherTarget = {
+      name: 'other-target',
+      paths: {
+        source: 'src/other-target',
+      },
+    };
+    const targets = {
+      getTarget: jest.fn(() => otherTarget),
+    };
+    const appServices = {
+      events,
+      targets,
+    };
+    const app = {
+      get: jest.fn((service) => appServices[service]),
+    };
+    const target = {
+      framework: 'react',
+      frameworkOptions: {
+        ssr: [otherTarget.name],
+      },
+    };
+    const currentLoader = {
+      test: /\.svg$/i,
+      include: [/fonts/i],
+    };
+    const currentRules = [currentLoader];
+    let sut = null;
+    let reducer = null;
+    let result = null;
+    const expectedRules = [Object.assign({}, currentLoader, {
+      include: [
+        currentLoader.include[0],
+        new RegExp(`${otherTarget.paths.source}/(?:.*?/)?fonts/.*?`, 'i'),
+      ],
+    })];
+    // When
+    sut = new ProjextReactPlugin();
+    sut.register(app);
+    [, [, reducer]] = events.on.mock.calls;
+    result = reducer(currentRules, { target });
+    // Then
+    expect(result).toEqual(expectedRules);
+  });
+
+  it('shouldn\'t modify the images rules of a target with an unknown framework property', () => {
+    // Given
+    const events = {
+      on: jest.fn(),
+    };
+    const app = {
+      get: jest.fn(() => events),
+    };
+    const target = {
+      framework: 'angularjs',
+    };
+    const currentRules = [{
+      test: /\.svg$/i,
+      use: [
+        'some-random-loader',
+      ],
+    }];
+    let sut = null;
+    let reducer = null;
+    let result = null;
+    // When
+    sut = new ProjextReactPlugin();
+    sut.register(app);
+    [,, [, reducer]] = events.on.mock.calls;
+    result = reducer(currentRules, { target });
+    // Then
+    expect(result).toEqual(currentRules);
+  });
+
+  it('shouldn\'t modify the images rules of a target that doesn\'t have framework options', () => {
+    // Given
+    const events = {
+      on: jest.fn(),
+    };
+    const app = {
+      get: jest.fn(() => events),
+    };
+    const target = {
+      framework: 'react',
+    };
+    const currentRules = [{
+      test: /\.svg$/i,
+      use: [
+        'some-random-loader',
+      ],
+    }];
+    let sut = null;
+    let reducer = null;
+    let result = null;
+    // When
+    sut = new ProjextReactPlugin();
+    sut.register(app);
+    [,, [, reducer]] = events.on.mock.calls;
+    result = reducer(currentRules, { target });
+    // Then
+    expect(result).toEqual(currentRules);
+  });
+
+  it('shouldn\'t modify the images rules of a target that doesn\'t implement SSR', () => {
+    // Given
+    const events = {
+      on: jest.fn(),
+    };
+    const app = {
+      get: jest.fn(() => events),
+    };
+    const target = {
+      framework: 'react',
+      frameworkOptions: {
+        ssr: [],
+      },
+    };
+    const currentRules = [{
+      test: /\.svg$/i,
+      use: [
+        'some-random-loader',
+      ],
+    }];
+    let sut = null;
+    let reducer = null;
+    let result = null;
+    // When
+    sut = new ProjextReactPlugin();
+    sut.register(app);
+    [,, [, reducer]] = events.on.mock.calls;
+    result = reducer(currentRules, { target });
+    // Then
+    expect(result).toEqual(currentRules);
+  });
+
+  it('shouldn\'t modify the images rules if there\'s no SVG loader', () => {
+    // Given
+    const events = {
+      on: jest.fn(),
+    };
+    const app = {
+      get: jest.fn(() => events),
+    };
+    const target = {
+      framework: 'react',
+      frameworkOptions: {
+        ssr: [],
+      },
+    };
+    const currentRules = [{
+      test: /\.not-svg$/i,
+      use: [
+        'some-random-loader',
+      ],
+    }];
+    let sut = null;
+    let reducer = null;
+    let result = null;
+    // When
+    sut = new ProjextReactPlugin();
+    sut.register(app);
+    [,, [, reducer]] = events.on.mock.calls;
+    result = reducer(currentRules, { target });
+    // Then
+    expect(result).toEqual(currentRules);
+  });
+
+  it('should update the fonts rules to include SSR targets', () => {
+    // Given
+    const events = {
+      on: jest.fn(),
+    };
+    const otherTarget = {
+      name: 'other-target',
+      paths: {
+        source: 'src/other-target',
+      },
+    };
+    const targets = {
+      getTarget: jest.fn(() => otherTarget),
+    };
+    const appServices = {
+      events,
+      targets,
+    };
+    const app = {
+      get: jest.fn((service) => appServices[service]),
+    };
+    const target = {
+      framework: 'react',
+      frameworkOptions: {
+        ssr: [otherTarget.name],
+      },
+    };
+    const currentLoader = {
+      test: /\.svg$/i,
+      exclude: /fonts/i,
+    };
+    const currentRules = [currentLoader];
+    let sut = null;
+    let reducer = null;
+    let result = null;
+    const expectedRules = [Object.assign({}, currentLoader, {
+      exclude: [
+        currentLoader.exclude,
+        new RegExp(`${otherTarget.paths.source}/(?:.*?/)?fonts/.*?`, 'i'),
+      ],
+    })];
+    // When
+    sut = new ProjextReactPlugin();
+    sut.register(app);
+    [,, [, reducer]] = events.on.mock.calls;
+    result = reducer(currentRules, { target });
+    // Then
+    expect(result).toEqual(expectedRules);
+  });
+
+  it('should update the images rules even if it already includes an `include` setting', () => {
+    // Given
+    const events = {
+      on: jest.fn(),
+    };
+    const otherTarget = {
+      name: 'other-target',
+      paths: {
+        source: 'src/other-target',
+      },
+    };
+    const targets = {
+      getTarget: jest.fn(() => otherTarget),
+    };
+    const appServices = {
+      events,
+      targets,
+    };
+    const app = {
+      get: jest.fn((service) => appServices[service]),
+    };
+    const target = {
+      framework: 'react',
+      frameworkOptions: {
+        ssr: [otherTarget.name],
+      },
+    };
+    const currentLoader = {
+      test: /\.svg$/i,
+      exclude: [/fonts/i],
+    };
+    const currentRules = [currentLoader];
+    let sut = null;
+    let reducer = null;
+    let result = null;
+    const expectedRules = [Object.assign({}, currentLoader, {
+      exclude: [
+        currentLoader.exclude[0],
+        new RegExp(`${otherTarget.paths.source}/(?:.*?/)?fonts/.*?`, 'i'),
+      ],
+    })];
+    // When
+    sut = new ProjextReactPlugin();
+    sut.register(app);
+    [,, [, reducer]] = events.on.mock.calls;
+    result = reducer(currentRules, { target });
+    // Then
+    expect(result).toEqual(expectedRules);
+  });
+
   it('shouldn\'t update the target entry if HMR is disabled', () => {
     // Given
     const events = {
@@ -365,7 +809,7 @@ describe('plugin:projextReact/main', () => {
     // When
     sut = new ProjextReactPlugin();
     sut.register(app);
-    [,, [, reducer]] = events.on.mock.calls;
+    [,,, [, reducer]] = events.on.mock.calls;
     result = reducer(targetConfig, { target });
     // Then
     expect(result).toEqual(targetConfig);
@@ -407,7 +851,7 @@ describe('plugin:projextReact/main', () => {
     // When
     sut = new ProjextReactPlugin();
     sut.register(app);
-    [,, [, reducer]] = events.on.mock.calls;
+    [,,, [, reducer]] = events.on.mock.calls;
     result = reducer(targetConfig, { target });
     // Then
     expect(result).toEqual(expectedConfig);
@@ -455,7 +899,7 @@ describe('plugin:projextReact/main', () => {
     // When
     sut = new ProjextReactPlugin();
     sut.register(app);
-    [,, [, reducer]] = events.on.mock.calls;
+    [,,, [, reducer]] = events.on.mock.calls;
     result = reducer(targetConfig, { target });
     // Then
     expect(result).toEqual(expectedConfig);


### PR DESCRIPTION
### What does this PR do?

When a Node target was building a browser target files, it would handle SVG files as both fonts and images, because the RegExp on the loaders are specific to the target being processed.

This fix add listeners for the fonts and images rules in order to include the paths for the SSR targets.

This is a breaking change because I changed a few properties and methods of the main service.

On the next major release I'll make most of the methods and properties private so changes like these won't be breaking, there's no reason to use the service outside the plugin.

### How should it be tested manually?

```bash
yarn test
# or
npm test
```
