### PR TITLE
Remove the listener that updates the CSS rules

### DIFF
--- a/src/plugin.js
+++ b/src/plugin.js
@@ -22,12 +22,6 @@ class ProjextReactPlugin {
     this.scssRulesEvent = 'webpack-scss-rules-configuration';
     /**
      * The name of the reducer event the service will listen in order to intercept the rules for
-     * css files and update them.
-     * @type {string}
-     */
-    this.cssRulesEvent = 'webpack-css-rules-configuration';
-    /**
-     * The name of the reducer event the service will listen in order to intercept the rules for
      * fonts files, and if the target implements SSR, update them.
      * @type {string}
      */
@@ -98,10 +92,6 @@ class ProjextReactPlugin {
     events.on(this.scssRulesEvent, (rules, params) => (
       this.updateStylesRules(rules, params.target, app.get('targets'))
     ));
-    // Add the listener for the CSS files rules event.
-    events.on(this.cssRulesEvent, (rules, params) => (
-      this.updateStylesRules(rules, params.target, app.get('targets'))
-    ));
     // Add the listener for the font files rules event.
     events.on(this.fontsRulesEvent, (rules, params) => (
       this.updateFontsRules(rules, params.target, app.get('targets'))
@@ -160,9 +150,9 @@ class ProjextReactPlugin {
     return currentRules;
   }
   /**
-   * This method gets called when projext reduces the stylesheet (for both SCSS and CSS) rules of a
-   * target. It validates the target settings, and if the target implements SSR, it adds the
-   * `include` setting on the rule for the SSR targets directories.
+   * This method gets called when projext reduces the SCSS rules of a target. It validates the
+   * target settings, and if the target implements SSR, it adds the `include` setting on the rule
+   * for the SSR targets directories.
    * @param {Array}   currentRules The list of fonts rules for the webpack configuration.
    * @param {Target}  target       The target information.
    * @param {Targets} targets      The targets service, to get the SSR targets information.

--- a/tests/plugin.test.js
+++ b/tests/plugin.test.js
@@ -14,7 +14,6 @@ describe('plugin:projextReact/main', () => {
     expect(sut).toBeInstanceOf(ProjextReactPlugin);
     expect(sut.jsRulesEvent).toBe('webpack-js-rules-configuration');
     expect(sut.scssRulesEvent).toBe('webpack-scss-rules-configuration');
-    expect(sut.cssRulesEvent).toBe('webpack-css-rules-configuration');
     expect(sut.fontsRulesEvent).toBe('webpack-fonts-rules-configuration');
     expect(sut.imagesRulesEvent).toBe('webpack-images-rules-configuration');
     expect(sut.targetEventName).toBe('webpack-browser-development-configuration');
@@ -37,7 +36,6 @@ describe('plugin:projextReact/main', () => {
     const expectedEvents = [
       'webpack-js-rules-configuration',
       'webpack-scss-rules-configuration',
-      'webpack-css-rules-configuration',
       'webpack-fonts-rules-configuration',
       'webpack-images-rules-configuration',
       'webpack-browser-development-configuration',
@@ -396,7 +394,7 @@ describe('plugin:projextReact/main', () => {
     // When
     sut = new ProjextReactPlugin();
     sut.register(app);
-    [,, [, reducer]] = events.on.mock.calls;
+    [, [, reducer]] = events.on.mock.calls;
     result = reducer(currentRules, { target });
     // Then
     expect(result).toEqual(currentRules);
@@ -526,7 +524,7 @@ describe('plugin:projextReact/main', () => {
     // When
     sut = new ProjextReactPlugin();
     sut.register(app);
-    [,, [, reducer]] = events.on.mock.calls;
+    [, [, reducer]] = events.on.mock.calls;
     result = reducer(currentRules, { target });
     // Then
     expect(result).toEqual(expectedRules);
@@ -555,7 +553,7 @@ describe('plugin:projextReact/main', () => {
     // When
     sut = new ProjextReactPlugin();
     sut.register(app);
-    [,,, [, reducer]] = events.on.mock.calls;
+    [,, [, reducer]] = events.on.mock.calls;
     result = reducer(currentRules, { target });
     // Then
     expect(result).toEqual(currentRules);
@@ -584,7 +582,7 @@ describe('plugin:projextReact/main', () => {
     // When
     sut = new ProjextReactPlugin();
     sut.register(app);
-    [,,, [, reducer]] = events.on.mock.calls;
+    [,, [, reducer]] = events.on.mock.calls;
     result = reducer(currentRules, { target });
     // Then
     expect(result).toEqual(currentRules);
@@ -616,7 +614,7 @@ describe('plugin:projextReact/main', () => {
     // When
     sut = new ProjextReactPlugin();
     sut.register(app);
-    [,,, [, reducer]] = events.on.mock.calls;
+    [,, [, reducer]] = events.on.mock.calls;
     result = reducer(currentRules, { target });
     // Then
     expect(result).toEqual(currentRules);
@@ -648,7 +646,7 @@ describe('plugin:projextReact/main', () => {
     // When
     sut = new ProjextReactPlugin();
     sut.register(app);
-    [,,, [, reducer]] = events.on.mock.calls;
+    [,, [, reducer]] = events.on.mock.calls;
     result = reducer(currentRules, { target });
     // Then
     expect(result).toEqual(currentRules);
@@ -698,7 +696,7 @@ describe('plugin:projextReact/main', () => {
     // When
     sut = new ProjextReactPlugin();
     sut.register(app);
-    [,,, [, reducer]] = events.on.mock.calls;
+    [,, [, reducer]] = events.on.mock.calls;
     result = reducer(currentRules, { target });
     // Then
     expect(result).toEqual(expectedRules);
@@ -748,7 +746,7 @@ describe('plugin:projextReact/main', () => {
     // When
     sut = new ProjextReactPlugin();
     sut.register(app);
-    [,,, [, reducer]] = events.on.mock.calls;
+    [,, [, reducer]] = events.on.mock.calls;
     result = reducer(currentRules, { target });
     // Then
     expect(result).toEqual(expectedRules);
@@ -777,7 +775,7 @@ describe('plugin:projextReact/main', () => {
     // When
     sut = new ProjextReactPlugin();
     sut.register(app);
-    [,,,, [, reducer]] = events.on.mock.calls;
+    [,,, [, reducer]] = events.on.mock.calls;
     result = reducer(currentRules, { target });
     // Then
     expect(result).toEqual(currentRules);
@@ -806,7 +804,7 @@ describe('plugin:projextReact/main', () => {
     // When
     sut = new ProjextReactPlugin();
     sut.register(app);
-    [,,,, [, reducer]] = events.on.mock.calls;
+    [,,, [, reducer]] = events.on.mock.calls;
     result = reducer(currentRules, { target });
     // Then
     expect(result).toEqual(currentRules);
@@ -870,7 +868,7 @@ describe('plugin:projextReact/main', () => {
     // When
     sut = new ProjextReactPlugin();
     sut.register(app);
-    [,,,, [, reducer]] = events.on.mock.calls;
+    [,,, [, reducer]] = events.on.mock.calls;
     result = reducer(currentRules, { target });
     // Then
     expect(result).toEqual(currentRules);
@@ -920,7 +918,7 @@ describe('plugin:projextReact/main', () => {
     // When
     sut = new ProjextReactPlugin();
     sut.register(app);
-    [,,,, [, reducer]] = events.on.mock.calls;
+    [,,, [, reducer]] = events.on.mock.calls;
     result = reducer(currentRules, { target });
     // Then
     expect(result).toEqual(expectedRules);
@@ -970,7 +968,7 @@ describe('plugin:projextReact/main', () => {
     // When
     sut = new ProjextReactPlugin();
     sut.register(app);
-    [,,,, [, reducer]] = events.on.mock.calls;
+    [,,, [, reducer]] = events.on.mock.calls;
     result = reducer(currentRules, { target });
     // Then
     expect(result).toEqual(expectedRules);
@@ -1001,7 +999,7 @@ describe('plugin:projextReact/main', () => {
     // When
     sut = new ProjextReactPlugin();
     sut.register(app);
-    [,,,,, [, reducer]] = events.on.mock.calls;
+    [,,,, [, reducer]] = events.on.mock.calls;
     result = reducer(targetConfig, { target });
     // Then
     expect(result).toEqual(targetConfig);
@@ -1043,7 +1041,7 @@ describe('plugin:projextReact/main', () => {
     // When
     sut = new ProjextReactPlugin();
     sut.register(app);
-    [,,,,, [, reducer]] = events.on.mock.calls;
+    [,,,, [, reducer]] = events.on.mock.calls;
     result = reducer(targetConfig, { target });
     // Then
     expect(result).toEqual(expectedConfig);
@@ -1091,7 +1089,7 @@ describe('plugin:projextReact/main', () => {
     // When
     sut = new ProjextReactPlugin();
     sut.register(app);
-    [,,,,, [, reducer]] = events.on.mock.calls;
+    [,,,, [, reducer]] = events.on.mock.calls;
     result = reducer(targetConfig, { target });
     // Then
     expect(result).toEqual(expectedConfig);


### PR DESCRIPTION
### What does this PR do?

On homer0/projext-plugin-webpack#24, I removed the `include` setting from the `CSS` rules as there was no need to limit that: The `include` setting should only be on rules that process and transform/transpile files, like the ones for `JS` and `SCSS`.

This plugin was processing the `CSS` rules in order to add SSR targets paths if needed, but before checking for SSR targets, it was re formatting the `include` setting:

```js
const include = Array.isArray(mainRule.include) ?
  mainRule.include :
  [mainRule.include];
```

And because the setting was removed, the rules ended with `include: [undefiend]`, ignoring all `CSS` files.

The fix was to remove the listener that updated the rules since the the setting is not longer needed.

### How should it be tested manually?

Before installing this branch, you can add [`font-awesome`](https://yarnpkg.com/en/package/font-awesome) to your project, import `font-awesome/css/font-awesome.css` and build, it should fail.

Now, try building with this branch, it should work as expected.

And of course...

```bash
yarn test
# or
npm test
```
